### PR TITLE
fix proper amount of data to dump (introduced by 3b5be84676)

### DIFF
--- a/src/mfoc.c
+++ b/src/mfoc.c
@@ -680,7 +680,7 @@ int main(int argc, char *const argv[])
     }
 
     // Finally save all keys + data to file
-    uint16_t dump_size = (t.num_blocks + 1) * t.num_sectors;
+    uint16_t dump_size = (t.num_blocks + 1) * sizeof(mifare_classic_block);
     if (fwrite(&mtDump, 1, dump_size, pfDump) != dump_size) {
       fprintf(stdout, "Error, cannot write dump\n");
       fclose(pfDump);


### PR DESCRIPTION
The dump_size must be the number of blocks times the size of one block.
(Without this patch, we end up for a 4K card (40 sectors, 256 blocks) with
dump_size == 256*40 == 10240 while sizeof(mtDump) == 4096,
resulting in a segfault.)
